### PR TITLE
chore(SPV-846): refactor examples to show extended errors

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -12,8 +12,20 @@ var ErrAdminKey = models.SPVError{Message: "an admin key must be set to be able 
 // ErrMissingXpriv is when xpriv is missing
 var ErrMissingXpriv = models.SPVError{Message: "xpriv missing", StatusCode: 401, Code: "error-unauthorized-xpriv-missing"}
 
+// ErrMissingXprivAndXpub is when xpriv and xpub are missing
+var ErrMissingXprivAndXpub = models.SPVError{Message: "xpriv and xpub missing", StatusCode: 404, Code: "error-shared-config-xpriv-and-xpub-missing"}
+
+// ErrMissingAccessKey is when access key is missing
+var ErrMissingAccessKey = models.SPVError{Message: "access key missing", StatusCode: 401, Code: "error-unauthorized-access-key-missing"}
+
 // ErrCouldNotFindDraftTransaction is when draft transaction is not found
 var ErrCouldNotFindDraftTransaction = models.SPVError{Message: "could not find draft transaction", StatusCode: 404, Code: "error-draft-transaction-not-found"}
+
+// ErrTotpInvalid is when totp is invalid
+var ErrTotpInvalid = models.SPVError{Message: "totp invalid", StatusCode: 400, Code: "error-totp-invalid"}
+
+// ErrContactPubKeyInvalid is when contact's PubKey is invalid
+var ErrContactPubKeyInvalid = models.SPVError{Message: "contact's PubKey is invalid", StatusCode: 400, Code: "error-contact-pubkey-invalid"}
 
 // WrapError wraps an error into SPVError
 func WrapError(err error) error {
@@ -21,7 +33,7 @@ func WrapError(err error) error {
 		return nil
 	}
 
-	return &models.SPVError{
+	return models.SPVError{
 		StatusCode: http.StatusInternalServerError,
 		Message:    err.Error(),
 		Code:       models.UnknownErrorCode,
@@ -34,14 +46,14 @@ func WrapResponseError(res *http.Response) error {
 		return nil
 	}
 
-	var resError *models.ResponseError
+	var resError models.ResponseError
 
 	err := json.NewDecoder(res.Body).Decode(&resError)
 	if err != nil {
 		return WrapError(err)
 	}
 
-	return &models.SPVError{
+	return models.SPVError{
 		StatusCode: res.StatusCode,
 		Code:       resError.Code,
 		Message:    resError.Message,
@@ -49,7 +61,7 @@ func WrapResponseError(res *http.Response) error {
 }
 
 func CreateErrorResponse(code string, message string) error {
-	return &models.SPVError{
+	return models.SPVError{
 		StatusCode: http.StatusInternalServerError,
 		Code:       code,
 		Message:    message,

--- a/errors.go
+++ b/errors.go
@@ -10,19 +10,19 @@ import (
 var ErrAdminKey = models.SPVError{Message: "an admin key must be set to be able to create an xpub", StatusCode: 401, Code: "error-unauthorized-admin-key-not-set"}
 
 // ErrMissingXpriv is when xpriv is missing
-var ErrMissingXpriv = models.SPVError{Message: "xpriv missing", StatusCode: 401, Code: "error-unauthorized-xpriv-missing"}
+var ErrMissingXpriv = models.SPVError{Message: "xpriv is missing", StatusCode: 401, Code: "error-unauthorized-xpriv-missing"}
 
-// ErrMissingXprivAndXpub is when xpriv and xpub are missing
-var ErrMissingXprivAndXpub = models.SPVError{Message: "xpriv and xpub missing", StatusCode: 404, Code: "error-shared-config-xpriv-and-xpub-missing"}
+// ErrMissingKey is when neither xPriv nor adminXPriv is provided
+var ErrMissingKey = models.SPVError{Message: "neither xPriv nor adminXPriv is provided", StatusCode: 404, Code: "error-shared-config-key-missing"}
 
 // ErrMissingAccessKey is when access key is missing
-var ErrMissingAccessKey = models.SPVError{Message: "access key missing", StatusCode: 401, Code: "error-unauthorized-access-key-missing"}
+var ErrMissingAccessKey = models.SPVError{Message: "access key is missing", StatusCode: 401, Code: "error-unauthorized-access-key-missing"}
 
 // ErrCouldNotFindDraftTransaction is when draft transaction is not found
 var ErrCouldNotFindDraftTransaction = models.SPVError{Message: "could not find draft transaction", StatusCode: 404, Code: "error-draft-transaction-not-found"}
 
 // ErrTotpInvalid is when totp is invalid
-var ErrTotpInvalid = models.SPVError{Message: "totp invalid", StatusCode: 400, Code: "error-totp-invalid"}
+var ErrTotpInvalid = models.SPVError{Message: "totp is invalid", StatusCode: 400, Code: "error-totp-invalid"}
 
 // ErrContactPubKeyInvalid is when contact's PubKey is invalid
 var ErrContactPubKeyInvalid = models.SPVError{Message: "contact's PubKey is invalid", StatusCode: 400, Code: "error-contact-pubkey-invalid"}

--- a/examples/README.md
+++ b/examples/README.md
@@ -35,7 +35,6 @@ In this directory you can find examples of how to use the `spv-wallet-go-client`
 In addition to the above, there are additional examples showing how to use the client from a developer perspective:
 
 -   `handle_exceptions` - presents how to "catch" exceptions which the client can throw
--   `custom_logger` - shows different ways you can configure (or disable) internal logger
 
 ## Util examples
 

--- a/examples/admin_add_user/admin_add_user.go
+++ b/examples/admin_add_user/admin_add_user.go
@@ -25,11 +25,11 @@ func main() {
 	metadata := map[string]any{"some_metadata": "example"}
 
 	newXPubRes := adminClient.AdminNewXpub(ctx, examples.ExampleXPub, metadata)
-	fmt.Println("AdminNewXpub response: ", newXPubRes)
+	examples.GetFullErrorMessage(newXPubRes)
 
 	createPaymailRes, err := adminClient.AdminCreatePaymail(ctx, examples.ExampleXPub, examples.ExamplePaymail, "Some public name", "")
 	if err != nil {
-		fmt.Println(err)
+		examples.GetFullErrorMessage(err)
 		os.Exit(1)
 	}
 	fmt.Println("AdminCreatePaymail response: ", createPaymailRes)

--- a/examples/admin_add_user/admin_add_user.go
+++ b/examples/admin_add_user/admin_add_user.go
@@ -24,8 +24,11 @@ func main() {
 
 	metadata := map[string]any{"some_metadata": "example"}
 
-	newXPubRes := adminClient.AdminNewXpub(ctx, examples.ExampleXPub, metadata)
-	examples.GetFullErrorMessage(newXPubRes)
+	err := adminClient.AdminNewXpub(ctx, examples.ExampleXPub, metadata)
+	if err != nil {
+		examples.GetFullErrorMessage(err)
+		os.Exit(1)
+	}
 
 	createPaymailRes, err := adminClient.AdminCreatePaymail(ctx, examples.ExampleXPub, examples.ExamplePaymail, "Some public name", "")
 	if err != nil {

--- a/examples/admin_remove_user/admin_remove_user.go
+++ b/examples/admin_remove_user/admin_remove_user.go
@@ -5,7 +5,6 @@ package main
 
 import (
 	"context"
-	"fmt"
 	"os"
 
 	walletclient "github.com/bitcoin-sv/spv-wallet-go-client"
@@ -24,7 +23,7 @@ func main() {
 
 	err := adminClient.AdminDeletePaymail(ctx, examples.ExamplePaymail)
 	if err != nil {
-		fmt.Println(err)
+		examples.GetFullErrorMessage(err)
 		os.Exit(1)
 	}
 }

--- a/examples/create_transaction/create_transaction.go
+++ b/examples/create_transaction/create_transaction.go
@@ -22,20 +22,20 @@ func main() {
 	client := walletclient.NewWithXPriv(server, examples.ExampleXPriv)
 	ctx := context.Background()
 
-	recipient := walletclient.Recipients{To: "receiver@example.com", Satoshis: 1}
+	recipient := walletclient.Recipients{To: "test-multiple1@pawel.test.4chain.space", Satoshis: 1}
 	recipients := []*walletclient.Recipients{&recipient}
 	metadata := map[string]any{"some_metadata": "example"}
 
 	newTransaction, err := client.SendToRecipients(ctx, recipients, metadata)
 	if err != nil {
-		fmt.Println(err)
+		examples.GetFullErrorMessage(err)
 		os.Exit(1)
 	}
 	fmt.Println("SendToRecipients response: ", newTransaction)
 
 	tx, err := client.GetTransaction(ctx, newTransaction.ID)
 	if err != nil {
-		fmt.Println(err)
+		examples.GetFullErrorMessage(err)
 		os.Exit(1)
 	}
 	fmt.Println("GetTransaction response: ", tx)

--- a/examples/errors.go
+++ b/examples/errors.go
@@ -1,0 +1,19 @@
+package examples
+
+import (
+	"errors"
+	"fmt"
+	"github.com/bitcoin-sv/spv-wallet/models"
+)
+
+func GetFullErrorMessage(err error) {
+	var errMsg string
+
+	var spvError models.SPVError
+	if errors.As(err, &spvError) {
+		errMsg = fmt.Sprintf("Error, Message: %s, Code: %s, HTTP status code: %d", spvError.GetMessage(), spvError.GetCode(), spvError.GetStatusCode())
+	} else {
+		errMsg = fmt.Sprintf("Error, Message: %s, Code: %s, HTTP status code: %d", err.Error(), models.UnknownErrorCode, 500)
+	}
+	fmt.Println(errMsg)
+}

--- a/examples/errors.go
+++ b/examples/errors.go
@@ -3,9 +3,11 @@ package examples
 import (
 	"errors"
 	"fmt"
+
 	"github.com/bitcoin-sv/spv-wallet/models"
 )
 
+// GetFullErrorMessage prints detailed info about the error
 func GetFullErrorMessage(err error) {
 	var errMsg string
 

--- a/examples/get_balance/get_balance.go
+++ b/examples/get_balance/get_balance.go
@@ -24,7 +24,7 @@ func main() {
 
 	xpubInfo, err := client.GetXPub(ctx)
 	if err != nil {
-		fmt.Println(err)
+		examples.GetFullErrorMessage(err)
 		os.Exit(1)
 	}
 	fmt.Println("Current balance: ", xpubInfo.CurrentBalance)

--- a/examples/handle_exceptions/handle_exceptions.go
+++ b/examples/handle_exceptions/handle_exceptions.go
@@ -5,34 +5,33 @@ package main
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"os"
 
 	walletclient "github.com/bitcoin-sv/spv-wallet-go-client"
 	"github.com/bitcoin-sv/spv-wallet-go-client/examples"
-	"github.com/bitcoin-sv/spv-wallet/models"
 )
 
 func main() {
 	defer examples.HandlePanic()
 
+	fmt.Println("Handle exceptions example")
+
 	examples.CheckIfXPubExists()
+
+	fmt.Println("XPub exists")
 
 	const server = "http://localhost:3003/v1"
 
 	client := walletclient.NewWithXPub(server, examples.ExampleXPub)
 	ctx := context.Background()
 
+	fmt.Println("Client created")
+
 	status, err := client.AdminGetStatus(ctx)
 	if err != nil {
-		var extendedErr models.ExtendedError
-		if errors.As(err, &extendedErr) {
-			fmt.Printf("Extended error: [%d] '%s': %s\n", extendedErr.GetStatusCode(), extendedErr.GetCode(), extendedErr.GetMessage())
-		} else {
-			fmt.Println("Error: ", err.Error())
-		}
-
+		fmt.Println("Error: ", err)
+		examples.GetFullErrorMessage(err)
 		os.Exit(1)
 	}
 

--- a/examples/list_transactions/list_transactions.go
+++ b/examples/list_transactions/list_transactions.go
@@ -30,7 +30,7 @@ func main() {
 
 	txs, err := client.GetTransactions(ctx, &conditions, metadata, &queryParams)
 	if err != nil {
-		fmt.Println(err)
+		examples.GetFullErrorMessage(err)
 		os.Exit(1)
 	}
 	fmt.Println("GetTransactions response: ", txs)
@@ -40,7 +40,7 @@ func main() {
 
 	txsFiltered, err := client.GetTransactions(ctx, &conditions, metadata, &queryParams)
 	if err != nil {
-		fmt.Println(err)
+		examples.GetFullErrorMessage(err)
 		os.Exit(1)
 	}
 	fmt.Println("Filtered GetTransactions response: ", txsFiltered)

--- a/examples/list_transactions/list_transactions.go
+++ b/examples/list_transactions/list_transactions.go
@@ -35,7 +35,8 @@ func main() {
 	}
 	fmt.Println("GetTransactions response: ", txs)
 
-	conditions = filter.TransactionFilter{BlockHeight: func(i uint64) *uint64 { return &i }(839228)}
+	targetBlockHeight := uint64(839228)
+	conditions = filter.TransactionFilter{BlockHeight: &targetBlockHeight}
 	queryParams = filter.QueryParams{PageSize: 100, Page: 1}
 
 	txsFiltered, err := client.GetTransactions(ctx, &conditions, metadata, &queryParams)

--- a/examples/send_op_return/send_op_return.go
+++ b/examples/send_op_return/send_op_return.go
@@ -30,19 +30,19 @@ func main() {
 
 	draftTransaction, err := client.DraftTransaction(ctx, &transactionConfig, metadata)
 	if err != nil {
-		fmt.Println(err)
+		examples.GetFullErrorMessage(err)
 		os.Exit(1)
 	}
 	fmt.Println("DraftTransaction response: ", draftTransaction)
 
 	finalized, err := client.FinalizeTransaction(draftTransaction)
 	if err != nil {
-		fmt.Println(err)
+		examples.GetFullErrorMessage(err)
 		os.Exit(1)
 	}
 	transaction, err := client.RecordTransaction(ctx, finalized, draftTransaction.ID, metadata)
 	if err != nil {
-		fmt.Println(err)
+		examples.GetFullErrorMessage(err)
 		os.Exit(1)
 	}
 	fmt.Println("Transaction with OP_RETURN: ", transaction)

--- a/examples/xpriv_from_mnemonic/xpriv_from_mnemonic.go
+++ b/examples/xpriv_from_mnemonic/xpriv_from_mnemonic.go
@@ -5,6 +5,7 @@ package main
 
 import (
 	"fmt"
+	"github.com/bitcoin-sv/spv-wallet-go-client/examples"
 	"os"
 
 	"github.com/bitcoin-sv/spv-wallet-go-client/xpriv"
@@ -16,7 +17,7 @@ func main() {
 
 	keys, err := xpriv.FromMnemonic(mnemonicPhrase)
 	if err != nil {
-		fmt.Println(err)
+		examples.GetFullErrorMessage(err)
 		os.Exit(1)
 	}
 

--- a/examples/xpub_from_xpriv/xpub_from_xpriv.go
+++ b/examples/xpub_from_xpriv/xpub_from_xpriv.go
@@ -5,6 +5,7 @@ package main
 
 import (
 	"fmt"
+	"github.com/bitcoin-sv/spv-wallet-go-client/examples"
 	"os"
 
 	"github.com/bitcoin-sv/spv-wallet-go-client/xpriv"
@@ -16,7 +17,7 @@ func main() {
 
 	keys, err := xpriv.FromString(xPriv)
 	if err != nil {
-		fmt.Println(err)
+		examples.GetFullErrorMessage(err)
 		os.Exit(1)
 	}
 

--- a/http.go
+++ b/http.go
@@ -665,7 +665,7 @@ func (wc *WalletClient) GetSharedConfig(ctx context.Context) (*models.SharedConf
 		key = wc.adminXPriv
 	}
 	if key == nil {
-		return nil, WrapError(ErrMissingXprivAndXpub)
+		return nil, WrapError(ErrMissingKey)
 	}
 	if err := wc.doHTTPRequest(
 		ctx, http.MethodGet, "/shared-config", nil, key, true, &model,

--- a/totp.go
+++ b/totp.go
@@ -3,8 +3,6 @@ package walletclient
 import (
 	"encoding/base32"
 	"encoding/hex"
-	"errors"
-	"fmt"
 	"time"
 
 	"github.com/bitcoin-sv/spv-wallet-go-client/utils"
@@ -15,9 +13,6 @@ import (
 	"github.com/pquerna/otp"
 	"github.com/pquerna/otp/totp"
 )
-
-// ErrClientInitNoXpriv error per init client with first xpriv key
-var ErrClientInitNoXpriv = errors.New("init client with xPriv first")
 
 const (
 	// TotpDefaultPeriod - Default number of seconds a TOTP is valid for.
@@ -84,7 +79,7 @@ func getTotpOpts(period, digits uint) *totp.ValidateOpts {
 
 func getSharedSecretFactors(b *WalletClient, c *models.Contact) (*bec.PrivateKey, *bec.PublicKey, error) {
 	if b.xPriv == nil {
-		return nil, nil, ErrClientInitNoXpriv
+		return nil, nil, ErrMissingXpriv
 	}
 
 	xpriv, err := deriveXprivForPki(b.xPriv)
@@ -99,7 +94,7 @@ func getSharedSecretFactors(b *WalletClient, c *models.Contact) (*bec.PrivateKey
 
 	pubKey, err := convertPubKey(c.PubKey)
 	if err != nil {
-		return nil, nil, fmt.Errorf("contact's PubKey is invalid: %w", err)
+		return nil, nil, ErrContactPubKeyInvalid
 	}
 
 	return privKey, pubKey, nil

--- a/totp_test.go
+++ b/totp_test.go
@@ -37,7 +37,7 @@ func TestGenerateTotpForContact(t *testing.T) {
 		_, err := sut.GenerateTotpForContact(nil, 30, 2)
 
 		// then
-		require.ErrorIs(t, err, ErrClientInitNoXpriv)
+		require.ErrorIs(t, err, ErrMissingXpriv)
 	})
 
 	t.Run("contact has invalid PubKey - returns error", func(t *testing.T) {

--- a/totp_test.go
+++ b/totp_test.go
@@ -50,7 +50,7 @@ func TestGenerateTotpForContact(t *testing.T) {
 		_, err := sut.GenerateTotpForContact(&contact, 30, 2)
 
 		// then
-		require.ErrorContains(t, err, "contact's PubKey is invalid:")
+		require.ErrorIs(t, err, ErrContactPubKeyInvalid)
 
 	})
 }


### PR DESCRIPTION
<!-- 
    Thank you for contributing to our project! Before you submit your Pull Request, please make sure you've completed the items in this checklist.
    Please check the boxes below by putting an x in the [ ] like so: [x]. You can do it right after creating the PR.
-->

# Pull Request Checklist

- [ ] 📖 I created my PR using provided  : [CODE_STANDARDS](https://github.com/bitcoin-sv/spv-wallet-go-client/blob/main/.github/CODE_STANDARDS.md)
- [ ] 📖 I have read the short Code of Conduct: [CODE_OF_CONDUCT](https://github.com/bitcoin-sv/spv-wallet-go-client/blob/main/.github/CODE_OF_CONDUCT.md)
- [ ] 🏠 I tested my changes locally.
- [ ] ✅ I have provided tests for my changes.
- [ ] 📝 I have used conventional commits.
- [ ] 📗 I have updated any related documentation.
- [ ] 💾 PR was issued based on the Github or Jira issue.

# Description

- Refactor examples to show extended errors
- Refactor methods which still return simple errors

<!-- 
## PR Title as Conventional Commit

Your PR title should also be a [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/). This will assist us in our release process and in assigning semantic version numbers to releases.
-->

<!-- 
## Related Tickets & Documents

If your changes relate to or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For instance, having the text "closes #1234" would link the current pull request to issue number 1234. And when we merge the pull request, Github will automatically close the issue.

- Related Issue #
- Closes #
-->

<!--
## Feature/Issue Details

Your pull request should be tightly connected to a feature or issue. Ensure that you've covered all necessary pathways and there's a possibility to test code behavior following the issue description or feature specification.
-->
