### PR TITLE
feat(SPV-1095): add merkleroots sync to go client

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -45,6 +45,14 @@ var ErrTotpInvalid = models.SPVError{Message: "totp is invalid", StatusCode: 400
 // ErrContactPubKeyInvalid is when contact's PubKey is invalid
 var ErrContactPubKeyInvalid = models.SPVError{Message: "contact's PubKey is invalid", StatusCode: 400, Code: "error-contact-pubkey-invalid"}
 
+// ErrStaleLastEvaluatedKey is when the last evaluated key returned from sync merkleroots is the same as it was in a previous iteration
+// indicating sync issue or a potential loop
+var ErrStaleLastEvaluatedKey = models.SPVError{Message: "The last evaluated key has not changed between requests, indicating a possible loop or synchronization issue.", StatusCode: 500, Code: "error-stale-last-evaluated-key"}
+
+// ErrStaleLastEvaluatedKey is when the last evaluated key returned from sync merkleroots is the same as it was in a previous iteration
+// indicating sync issue or a potential loop
+var ErrSyncMerkleRootsTimeout = models.SPVError{Message: "SyncMerkleRoots operation timed out", StatusCode: 500, Code: "error-sync-merkleroots-timeout"}
+
 // WrapError wraps an error into SPVError
 func WrapError(err error) error {
 	if err == nil {

--- a/examples/Taskfile.yml
+++ b/examples/Taskfile.yml
@@ -71,3 +71,8 @@ tasks:
     cmds:
       - echo "running webhooks..."
       - go run ./webhooks/webhooks.go || true
+  sync_merkleroots:
+    desc: "running sync_merkleroots.."
+    cmds:
+      - echo "running sync_merkleroots..."
+      - go run ./sync_merkleroots/sync_merkleroots.go

--- a/examples/sync_merkleroots/sync_merkleroots.go
+++ b/examples/sync_merkleroots/sync_merkleroots.go
@@ -22,7 +22,6 @@ type db struct {
 func (db *db) SaveMerkleRoots(syncedMerkleRoots []models.MerkleRoot) error {
 	fmt.Print("\nSaveMerkleRoots called\n")
 	db.MerkleRoots = append(db.MerkleRoots, syncedMerkleRoots...)
-	time.Sleep(1 * time.Second)
 	return nil
 }
 
@@ -71,12 +70,13 @@ func main() {
 		examples.GetFullErrorMessage(err)
 		os.Exit(1)
 	}
-	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(context.Background(), 1000*time.Millisecond)
+	defer cancel()
 
 	fmt.Printf("\n\n Initial State Length: \n %d\n\n", len(repository.MerkleRoots))
 	fmt.Printf("\n\nInitial State Last 5 MerkleRoots (or fewer):\n%+v\n", getLastFiveOrFewer(repository.MerkleRoots))
 
-	err = client.SyncMerkleRoots(ctx, repository, 1000*time.Millisecond)
+	err = client.SyncMerkleRoots(ctx, repository)
 	if err != nil {
 		fmt.Println("Error: ", err)
 		examples.GetFullErrorMessage(err)

--- a/examples/sync_merkleroots/sync_merkleroots.go
+++ b/examples/sync_merkleroots/sync_merkleroots.go
@@ -65,13 +65,18 @@ func main() {
 
 	server := "http://localhost:3003/api/v1"
 
-	client := walletclient.NewWithXPriv(server, examples.ExampleXPriv)
+	client, err := walletclient.NewWithXPriv(server, examples.ExampleXPriv)
+	if err != nil {
+		fmt.Println("Error: ", err)
+		examples.GetFullErrorMessage(err)
+		os.Exit(1)
+	}
 	ctx := context.Background()
 
 	fmt.Printf("\n\n Initial State Length: \n %d\n\n", len(repository.MerkleRoots))
 	fmt.Printf("\n\nInitial State Last 5 MerkleRoots (or fewer):\n%+v\n", getLastFiveOrFewer(repository.MerkleRoots))
 
-	err := client.SyncMerkleRoots(ctx, repository, 1000*time.Millisecond)
+	err = client.SyncMerkleRoots(ctx, repository, 1000*time.Millisecond)
 	if err != nil {
 		fmt.Println("Error: ", err)
 		examples.GetFullErrorMessage(err)

--- a/examples/sync_merkleroots/sync_merkleroots.go
+++ b/examples/sync_merkleroots/sync_merkleroots.go
@@ -25,7 +25,7 @@ func (db *db) SaveMerkleRoots(syncedMerkleRoots []walletclient.MerkleRoot) error
 	return nil
 }
 
-func (db *db) GetLastEvaluatedKey() string {
+func (db *db) GetLastMerkleRoot() string {
 	if len(db.MerkleRoots) == 0 {
 		return ""
 	}

--- a/examples/sync_merkleroots/sync_merkleroots.go
+++ b/examples/sync_merkleroots/sync_merkleroots.go
@@ -11,14 +11,15 @@ import (
 
 	walletclient "github.com/bitcoin-sv/spv-wallet-go-client"
 	"github.com/bitcoin-sv/spv-wallet-go-client/examples"
+	"github.com/bitcoin-sv/spv-wallet-go-client/models"
 )
 
 // simulate a storage of merkle roots that exists on a client side that is using SyncMerkleRoots method
 type db struct {
-	MerkleRoots []walletclient.MerkleRoot
+	MerkleRoots []models.MerkleRoot
 }
 
-func (db *db) SaveMerkleRoots(syncedMerkleRoots []walletclient.MerkleRoot) error {
+func (db *db) SaveMerkleRoots(syncedMerkleRoots []models.MerkleRoot) error {
 	fmt.Print("\nSaveMerkleRoots called\n")
 	db.MerkleRoots = append(db.MerkleRoots, syncedMerkleRoots...)
 	time.Sleep(1 * time.Second)
@@ -34,7 +35,7 @@ func (db *db) GetLastMerkleRoot() string {
 
 // initalize the storage that exists on a client side
 var repository = &db{
-	MerkleRoots: []walletclient.MerkleRoot{
+	MerkleRoots: []models.MerkleRoot{
 		{
 			MerkleRoot:  "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b",
 			BlockHeight: 0,
@@ -50,7 +51,7 @@ var repository = &db{
 	},
 }
 
-func getLastFiveOrFewer(merkleroots []walletclient.MerkleRoot) []walletclient.MerkleRoot {
+func getLastFiveOrFewer(merkleroots []models.MerkleRoot) []models.MerkleRoot {
 	startIndex := len(merkleroots) - 5
 	if startIndex < 0 {
 		startIndex = 0

--- a/examples/sync_merkleroots/sync_merkleroots.go
+++ b/examples/sync_merkleroots/sync_merkleroots.go
@@ -13,12 +13,13 @@ import (
 	"github.com/bitcoin-sv/spv-wallet-go-client/examples"
 )
 
-// simulate database
+// simulate a storage of merkle roots that exists on a client side that is using SyncMerkleRoots method
 type db struct {
 	MerkleRoots []walletclient.MerkleRoot
 }
 
 func (db *db) SaveMerkleRoots(syncedMerkleRoots []walletclient.MerkleRoot) error {
+	fmt.Print("\nSaveMerkleRoots called\n")
 	db.MerkleRoots = append(db.MerkleRoots, syncedMerkleRoots...)
 	time.Sleep(1 * time.Second)
 	return nil
@@ -31,7 +32,7 @@ func (db *db) GetLastEvaluatedKey() string {
 	return db.MerkleRoots[len(db.MerkleRoots)-1].MerkleRoot
 }
 
-// simulate repository
+// initalize the storage that exists on a client side
 var repository = &db{
 	MerkleRoots: []walletclient.MerkleRoot{
 		{
@@ -46,10 +47,6 @@ var repository = &db{
 			MerkleRoot:  "9b0fc92260312ce44e74ef369f5c66bbb85848f2eddd5a7a1cde251e54ccfdd5",
 			BlockHeight: 2,
 		},
-		{
-			MerkleRoot:  "612209eca3ff078e55d1ffe4602e78ac9a53458c7f9196b38c232d8af9ed635d",
-			BlockHeight: 864550,
-		},
 	},
 }
 
@@ -58,18 +55,17 @@ func main() {
 
 	server := "http://localhost:3003/api/v1"
 
-	// client := walletclient.NewWithAccessKey(server, examples.ExampleAccessKey)
 	client := walletclient.NewWithXPriv(server, examples.ExampleXPriv)
 	ctx := context.Background()
 
-	fmt.Printf("\n\n Initial State: \n %+v\n\n", repository.MerkleRoots)
+	fmt.Printf("\n\n Initial State: \n %d\n\n", len(repository.MerkleRoots))
 
-	err := client.SyncMerkleRoots(ctx, repository)
+	err := client.SyncMerkleRoots(ctx, repository, 1000*time.Millisecond)
 	if err != nil {
 		fmt.Println("Error: ", err)
 		examples.GetFullErrorMessage(err)
 		os.Exit(1)
 	}
 
-	fmt.Printf("\n\n After Sync State: \n %+v\n\n", repository.MerkleRoots)
+	fmt.Printf("\n\n After Sync State: \n %d\n\n", len(repository.MerkleRoots))
 }

--- a/examples/sync_merkleroots/sync_merkleroots.go
+++ b/examples/sync_merkleroots/sync_merkleroots.go
@@ -1,0 +1,75 @@
+/*
+Package main - sync_merkleroots example
+*/
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	walletclient "github.com/bitcoin-sv/spv-wallet-go-client"
+	"github.com/bitcoin-sv/spv-wallet-go-client/examples"
+)
+
+// simulate database
+type db struct {
+	MerkleRoots []walletclient.MerkleRoot
+}
+
+func (db *db) SaveMerkleRoots(syncedMerkleRoots []walletclient.MerkleRoot) error {
+	db.MerkleRoots = append(db.MerkleRoots, syncedMerkleRoots...)
+	time.Sleep(1 * time.Second)
+	return nil
+}
+
+func (db *db) GetLastEvaluatedKey() string {
+	if len(db.MerkleRoots) == 0 {
+		return ""
+	}
+	return db.MerkleRoots[len(db.MerkleRoots)-1].MerkleRoot
+}
+
+// simulate repository
+var repository = &db{
+	MerkleRoots: []walletclient.MerkleRoot{
+		{
+			MerkleRoot:  "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b",
+			BlockHeight: 0,
+		},
+		{
+			MerkleRoot:  "0e3e2357e806b6cdb1f70b54c3a3a17b6714ee1f0e68bebb44a74b1efd512098",
+			BlockHeight: 1,
+		},
+		{
+			MerkleRoot:  "9b0fc92260312ce44e74ef369f5c66bbb85848f2eddd5a7a1cde251e54ccfdd5",
+			BlockHeight: 2,
+		},
+		{
+			MerkleRoot:  "612209eca3ff078e55d1ffe4602e78ac9a53458c7f9196b38c232d8af9ed635d",
+			BlockHeight: 864550,
+		},
+	},
+}
+
+func main() {
+	defer examples.HandlePanic()
+
+	server := "http://localhost:3003/api/v1"
+
+	// client := walletclient.NewWithAccessKey(server, examples.ExampleAccessKey)
+	client := walletclient.NewWithXPriv(server, examples.ExampleXPriv)
+	ctx := context.Background()
+
+	fmt.Printf("\n\n Initial State: \n %+v\n\n", repository.MerkleRoots)
+
+	err := client.SyncMerkleRoots(ctx, repository)
+	if err != nil {
+		fmt.Println("Error: ", err)
+		examples.GetFullErrorMessage(err)
+		os.Exit(1)
+	}
+
+	fmt.Printf("\n\n After Sync State: \n %+v\n\n", repository.MerkleRoots)
+}

--- a/examples/sync_merkleroots/sync_merkleroots.go
+++ b/examples/sync_merkleroots/sync_merkleroots.go
@@ -50,6 +50,15 @@ var repository = &db{
 	},
 }
 
+func getLastFiveOrFewer(merkleroots []walletclient.MerkleRoot) []walletclient.MerkleRoot {
+	startIndex := len(merkleroots) - 5
+	if startIndex < 0 {
+		startIndex = 0
+	}
+
+	return merkleroots[startIndex:]
+}
+
 func main() {
 	defer examples.HandlePanic()
 
@@ -58,7 +67,8 @@ func main() {
 	client := walletclient.NewWithXPriv(server, examples.ExampleXPriv)
 	ctx := context.Background()
 
-	fmt.Printf("\n\n Initial State: \n %d\n\n", len(repository.MerkleRoots))
+	fmt.Printf("\n\n Initial State Length: \n %d\n\n", len(repository.MerkleRoots))
+	fmt.Printf("\n\nInitial State Last 5 MerkleRoots (or fewer):\n%+v\n", getLastFiveOrFewer(repository.MerkleRoots))
 
 	err := client.SyncMerkleRoots(ctx, repository, 1000*time.Millisecond)
 	if err != nil {
@@ -67,5 +77,6 @@ func main() {
 		os.Exit(1)
 	}
 
-	fmt.Printf("\n\n After Sync State: \n %d\n\n", len(repository.MerkleRoots))
+	fmt.Printf("\n\n After Sync State Length: \n %d\n\n", len(repository.MerkleRoots))
+	fmt.Printf("\n\n After Sync State Last 5 MerkleRoots (or fewer):\n%+v\n", getLastFiveOrFewer(repository.MerkleRoots))
 }

--- a/fixtures/spv_wallet.go
+++ b/fixtures/spv_wallet.go
@@ -1,0 +1,121 @@
+package fixtures
+
+import (
+	"slices"
+
+	"github.com/bitcoin-sv/spv-wallet-go-client/models"
+)
+
+const (
+	SPVWalletURL = "http://localhost:3003/api/v1"
+)
+
+// MockedSPVWalletData is mocked  merkle roots data on spv-wallet side
+var MockedSPVWalletData = []models.MerkleRoot{
+	{
+		BlockHeight: 0,
+		MerkleRoot:  "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b",
+	},
+	{
+		BlockHeight: 1,
+		MerkleRoot:  "0e3e2357e806b6cdb1f70b54c3a3a17b6714ee1f0e68bebb44a74b1efd512098",
+	},
+	{
+		BlockHeight: 2,
+		MerkleRoot:  "9b0fc92260312ce44e74ef369f5c66bbb85848f2eddd5a7a1cde251e54ccfdd5",
+	},
+	{
+		BlockHeight: 3,
+		MerkleRoot:  "999e1c837c76a1b7fbb7e57baf87b309960f5ffefbf2a9b95dd890602272f644",
+	},
+	{
+		BlockHeight: 4,
+		MerkleRoot:  "df2b060fa2e5e9c8ed5eaf6a45c13753ec8c63282b2688322eba40cd98ea067a",
+	},
+	{
+		BlockHeight: 5,
+		MerkleRoot:  "63522845d294ee9b0188ae5cac91bf389a0c3723f084ca1025e7d9cdfe481ce1",
+	},
+	{
+		BlockHeight: 6,
+		MerkleRoot:  "20251a76e64e920e58291a30d4b212939aae976baca40e70818ceaa596fb9d37",
+	},
+	{
+		BlockHeight: 7,
+		MerkleRoot:  "8aa673bc752f2851fd645d6a0a92917e967083007d9c1684f9423b100540673f",
+	},
+	{
+		BlockHeight: 8,
+		MerkleRoot:  "a6f7f1c0dad0f2eb6b13c4f33de664b1b0e9f22efad5994a6d5b6086d85e85e3",
+	},
+	{
+		BlockHeight: 9,
+		MerkleRoot:  "0437cd7f8525ceed2324359c2d0ba26006d92d856a9c20fa0241106ee5a597c9",
+	},
+	{
+		BlockHeight: 10,
+		MerkleRoot:  "d3ad39fa52a89997ac7381c95eeffeaf40b66af7a57e9eba144be0a175a12b11",
+	},
+	{
+		BlockHeight: 11,
+		MerkleRoot:  "f8325d8f7fa5d658ea143629288d0530d2710dc9193ddc067439de803c37066e",
+	},
+	{
+		BlockHeight: 12,
+		MerkleRoot:  "3b96bb7e197ef276b85131afd4a09c059cc368133a26ca04ebffb0ab4f75c8b8",
+	},
+	{
+		BlockHeight: 13,
+		MerkleRoot:  "9962d5c704ec27243364cbe9d384808feeac1c15c35ac790dffd1e929829b271",
+	},
+	{
+		BlockHeight: 14,
+		MerkleRoot:  "e1afd89295b68bc5247fe0ca2885dd4b8818d7ce430faa615067d7bab8640156",
+	},
+}
+
+// MockedMerkleRootsAPIResponseFn is a mock of SPV-Wallet it will return a paged response of merkle roots since last evaluated merkle root
+func MockedMerkleRootsAPIResponseFn(lastMerkleRoot string) models.ExclusiveStartKeyPage[[]models.MerkleRoot] {
+	if lastMerkleRoot == "" {
+		return models.ExclusiveStartKeyPage[[]models.MerkleRoot]{
+			Content: MockedSPVWalletData,
+			Page: models.ExclusiveStartKeyPageInfo{
+				LastEvaluatedKey: "",
+				TotalElements:    len(MockedSPVWalletData),
+				Size:             len(MockedSPVWalletData),
+			},
+		}
+	}
+
+	lastMerkleRootIdx := slices.IndexFunc(MockedSPVWalletData, func(mr models.MerkleRoot) bool {
+		return mr.MerkleRoot == lastMerkleRoot
+	})
+
+	// handle case when lastMerkleRoot is already highest in the servers database
+	if lastMerkleRootIdx == len(MockedSPVWalletData)-1 {
+		return models.ExclusiveStartKeyPage[[]models.MerkleRoot]{
+			Content: []models.MerkleRoot{},
+			Page: models.ExclusiveStartKeyPageInfo{
+				LastEvaluatedKey: "",
+				TotalElements:    len(MockedSPVWalletData),
+				Size:             0,
+			},
+		}
+	}
+
+	content := MockedSPVWalletData[lastMerkleRootIdx+1:]
+	lastEvaluatedKey := content[len(content)-1].MerkleRoot
+
+	if lastEvaluatedKey == MockedSPVWalletData[len(MockedSPVWalletData)-1].MerkleRoot {
+		lastEvaluatedKey = ""
+	}
+
+	return models.ExclusiveStartKeyPage[[]models.MerkleRoot]{
+		Content: content,
+		Page: models.ExclusiveStartKeyPageInfo{
+			LastEvaluatedKey: lastEvaluatedKey,
+			TotalElements:    len(MockedSPVWalletData),
+			Size:             len(content),
+		},
+	}
+}

--- a/fixtures/spv_wallet.go
+++ b/fixtures/spv_wallet.go
@@ -74,6 +74,11 @@ var MockedSPVWalletData = []models.MerkleRoot{
 	},
 }
 
+// LastMockedMerkleRoot returns last merkleroot value from MockedSPVWalletData
+func LastMockedMerkleRoot() models.MerkleRoot {
+	return MockedSPVWalletData[len(MockedSPVWalletData)-1]
+}
+
 // MockedMerkleRootsAPIResponseFn is a mock of SPV-Wallet it will return a paged response of merkle roots since last evaluated merkle root
 func MockedMerkleRootsAPIResponseFn(lastMerkleRoot string) models.ExclusiveStartKeyPage[[]models.MerkleRoot] {
 	if lastMerkleRoot == "" {

--- a/fixtures/sync_merkleroots.go
+++ b/fixtures/sync_merkleroots.go
@@ -1,0 +1,122 @@
+package fixtures
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"time"
+
+	"github.com/bitcoin-sv/spv-wallet-go-client/models"
+)
+
+// simulate a storage of merkle roots that exists on a client side that is using SyncMerkleRoots method
+type DB struct {
+	MerkleRoots []models.MerkleRoot
+}
+
+func (db *DB) SaveMerkleRoots(syncedMerkleRoots []models.MerkleRoot) error {
+	db.MerkleRoots = append(db.MerkleRoots, syncedMerkleRoots...)
+	time.Sleep(5 * time.Millisecond)
+	return nil
+}
+
+func (db *DB) GetLastMerkleRoot() string {
+	if len(db.MerkleRoots) == 0 {
+		return ""
+	}
+	return db.MerkleRoots[len(db.MerkleRoots)-1].MerkleRoot
+}
+
+// CreateRepository creates a simulated repository a client passes to SyncMerkleRoots()
+func CreateRepository(merkleRoots []models.MerkleRoot) *DB {
+	return &DB{
+		MerkleRoots: merkleRoots,
+	}
+}
+
+func sendJSONResponse(data interface{}, w *http.ResponseWriter) {
+	(*w).Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(*w).Encode(data); err != nil {
+		(*w).WriteHeader(http.StatusInternalServerError)
+	}
+}
+
+func MockMerkleRootsAPIResponseNormal() *httptest.Server {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Sprintf("%+v", r.URL)
+		switch {
+		case r.URL.Path == "/api/v1/merkleroots" && r.Method == http.MethodGet:
+			lastEvaluatedKey := r.URL.Query().Get("lastEvaluatedKey")
+			sendJSONResponse(MockedMerkleRootsAPIResponseFn(lastEvaluatedKey), &w)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+
+	return server
+}
+
+func MockMerkleRootsAPIResponseDelayed() *httptest.Server {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/api/v1/merkleroots" && r.Method == http.MethodGet:
+			lastEvaluatedKey := r.URL.Query().Get("lastEvaluatedKey")
+			// it is to limit the result up to 3 merkle roots per request to ensure
+			// that the sync merkleroots will loop more than once and hit the timeout
+			all := MockedMerkleRootsAPIResponseFn(lastEvaluatedKey)
+			if len(all.Content) > 3 {
+				all.Content = all.Content[:3]
+			}
+
+			all.Page.Size = len(all.Content)
+
+			if len(all.Content) > 0 {
+				all.Page.LastEvaluatedKey = all.Content[len(all.Content)-1].MerkleRoot
+			} else {
+				all.Page.LastEvaluatedKey = ""
+			}
+
+			time.Sleep(50 * time.Millisecond)
+			sendJSONResponse(all, &w)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+
+	return server
+}
+
+func MockMerkleRootsAPIResponseStale() *httptest.Server {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/api/v1/merkleroots" && r.Method == http.MethodGet:
+			staleLastEvaluatedKeyResponse := models.ExclusiveStartKeyPage[[]models.MerkleRoot]{
+				Content: []models.MerkleRoot{
+					{
+						MerkleRoot:  "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b",
+						BlockHeight: 0,
+					},
+					{
+						MerkleRoot:  "0e3e2357e806b6cdb1f70b54c3a3a17b6714ee1f0e68bebb44a74b1efd512098",
+						BlockHeight: 1,
+					},
+					{
+						MerkleRoot:  "9b0fc92260312ce44e74ef369f5c66bbb85848f2eddd5a7a1cde251e54ccfdd5",
+						BlockHeight: 2,
+					},
+				},
+				Page: models.ExclusiveStartKeyPageInfo{
+					LastEvaluatedKey: "9b0fc92260312ce44e74ef369f5c66bbb85848f2eddd5a7a1cde251e54ccfdd5",
+					Size:             3,
+					TotalElements:    len(MockedSPVWalletData),
+				},
+			}
+			sendJSONResponse(staleLastEvaluatedKeyResponse, &w)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+
+	return server
+}

--- a/fixtures/sync_merkleroots.go
+++ b/fixtures/sync_merkleroots.go
@@ -2,7 +2,6 @@ package fixtures
 
 import (
 	"encoding/json"
-	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"time"
@@ -44,9 +43,8 @@ func sendJSONResponse(data interface{}, w *http.ResponseWriter) {
 
 func MockMerkleRootsAPIResponseNormal() *httptest.Server {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		fmt.Sprintf("%+v", r.URL)
 		switch {
-		case r.URL.Path == "/api/v1/merkleroots" && r.Method == http.MethodGet:
+		case r.URL.Path == "/v1/merkleroots" && r.Method == http.MethodGet:
 			lastEvaluatedKey := r.URL.Query().Get("lastEvaluatedKey")
 			sendJSONResponse(MockedMerkleRootsAPIResponseFn(lastEvaluatedKey), &w)
 		default:
@@ -60,7 +58,7 @@ func MockMerkleRootsAPIResponseNormal() *httptest.Server {
 func MockMerkleRootsAPIResponseDelayed() *httptest.Server {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
-		case r.URL.Path == "/api/v1/merkleroots" && r.Method == http.MethodGet:
+		case r.URL.Path == "/v1/merkleroots" && r.Method == http.MethodGet:
 			lastEvaluatedKey := r.URL.Query().Get("lastEvaluatedKey")
 			// it is to limit the result up to 3 merkle roots per request to ensure
 			// that the sync merkleroots will loop more than once and hit the timeout
@@ -90,7 +88,7 @@ func MockMerkleRootsAPIResponseDelayed() *httptest.Server {
 func MockMerkleRootsAPIResponseStale() *httptest.Server {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
-		case r.URL.Path == "/api/v1/merkleroots" && r.Method == http.MethodGet:
+		case r.URL.Path == "/v1/merkleroots" && r.Method == http.MethodGet:
 			staleLastEvaluatedKeyResponse := models.ExclusiveStartKeyPage[[]models.MerkleRoot]{
 				Content: []models.MerkleRoot{
 					{

--- a/fixtures/sync_merkleroots.go
+++ b/fixtures/sync_merkleroots.go
@@ -16,7 +16,6 @@ type DB struct {
 
 func (db *DB) SaveMerkleRoots(syncedMerkleRoots []models.MerkleRoot) error {
 	db.MerkleRoots = append(db.MerkleRoots, syncedMerkleRoots...)
-	time.Sleep(5 * time.Millisecond)
 	return nil
 }
 

--- a/models/sync_merkleroots.go
+++ b/models/sync_merkleroots.go
@@ -1,0 +1,38 @@
+package models
+
+// ExclusiveStartKeyPage represents a paginated response for database records using Exclusive Start Key paging
+type ExclusiveStartKeyPage[T any] struct {
+	// List of records for the response
+	Content T
+	// Pagination details
+	Page ExclusiveStartKeyPageInfo
+}
+
+// ExclusiveStartKeyPageInfo represents the pagination information for limiting and sorting database query results
+type ExclusiveStartKeyPageInfo struct {
+	// Field by which to order the results
+	OrderByField *string `json:"orderByField,omitempty"` // Optional ordering field
+	// Direction in which to order the results (ASC or DESC)
+	SortDirection *string `json:"sortDirection,omitempty"` // Optional sort direction
+	// Total count of elements
+	TotalElements int `json:"totalElements"`
+	// Size of the page or returned data
+	Size int `json:"size"`
+	// Last evaluated key returned from the database
+	LastEvaluatedKey string `json:"lastEvaluatedKey"`
+}
+
+// MerkleRoot holds the content of the synced Merkle root response
+type MerkleRoot struct {
+	MerkleRoot  string `json:"merkleRoot"`
+	BlockHeight int    `json:"blockHeight"`
+}
+
+// MerkleRootsRepository is an interface responsible for saving synced merkleroots and getting last evaluat key from database
+type MerkleRootsRepository interface {
+	// GetLastMerkleRoot should return the merkle root with the heighest height from your storage or undefined if empty
+	GetLastMerkleRoot() string
+	// SaveMerkleRoots should store newly synced merkle roots into your storage;
+	// NOTE: items are ordered with ascending order by block height
+	SaveMerkleRoots(syncedMerkleRoots []MerkleRoot) error
+}

--- a/sync_merkleroots.go
+++ b/sync_merkleroots.go
@@ -37,8 +37,8 @@ type MerkleRoot struct {
 
 // MerkleRootsRepository is an interface responsible for saving synced merkleroots and getting last evaluat key from database
 type MerkleRootsRepository interface {
-	// GetLastEvaluatedKey should return the merkle root with the heighest height from your storage or undefined if empty
-	GetLastEvaluatedKey() string
+	// GetLastMerkleRoot should return the merkle root with the heighest height from your storage or undefined if empty
+	GetLastMerkleRoot() string
 	// SaveMerkleRoots should store newly synced merkle roots into your storage;
 	// NOTE: items are ordered with ascending order by block height
 	SaveMerkleRoots(syncedMerkleRoots []MerkleRoot) error
@@ -52,7 +52,7 @@ func (wc *WalletClient) SyncMerkleRoots(ctx context.Context, repo MerkleRootsRep
 		defer cancel()
 	}
 
-	lastEvaluatedKey := repo.GetLastEvaluatedKey()
+	lastEvaluatedKey := repo.GetLastMerkleRoot()
 	requestPath := "merkleroots"
 	lastEvaluatedKeyQuery := ""
 	previousLastEvaluatedKey := lastEvaluatedKey

--- a/sync_merkleroots.go
+++ b/sync_merkleroots.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"time"
 )
 
 // exclusiveStartKeyPage represents a paginated response for database records using Exclusive Start Key paging
@@ -34,42 +35,62 @@ type MerkleRoot struct {
 	BlockHeight int    `json:"blockHeight"`
 }
 
-// Repository is an interface responsible for saving synced merkleroots and getting last evaluat key from database
-type Repository interface {
+// MerkleRootsRepository is an interface responsible for saving synced merkleroots and getting last evaluat key from database
+type MerkleRootsRepository interface {
+	// GetLastEvaluatedKey should return the merkle root with the heighest height from your storage or undefined if empty
 	GetLastEvaluatedKey() string
+	// SaveMerkleRoots should store newly synced merkle roots into your storage;
+	// NOTE: items are ordered with ascending order by block height
 	SaveMerkleRoots(syncedMerkleRoots []MerkleRoot) error
 }
 
 // SyncMerkleRoots syncs merkleroots known to spv-wallet with the client database
-func (wc *WalletClient) SyncMerkleRoots(ctx context.Context, repo Repository) error {
+func (wc *WalletClient) SyncMerkleRoots(ctx context.Context, repo MerkleRootsRepository, timeoutMs time.Duration) error {
+	var cancel context.CancelFunc
+	if timeoutMs > 0 {
+		ctx, cancel = context.WithTimeout(ctx, timeoutMs)
+		defer cancel()
+	}
+
 	lastEvaluatedKey := repo.GetLastEvaluatedKey()
 	requestPath := "merkleroots"
 	lastEvaluatedKeyQuery := ""
+	previousLastEvaluatedKey := lastEvaluatedKey
 
 	if lastEvaluatedKey != "" {
 		lastEvaluatedKeyQuery = fmt.Sprintf("?lastEvaluatedKey=%s", lastEvaluatedKey)
 	}
 
 	for {
-		url := fmt.Sprintf("/%s%s", requestPath, lastEvaluatedKeyQuery)
+		select {
+		case <-ctx.Done():
+			return ErrSyncMerkleRootsTimeout
+		default:
+			url := fmt.Sprintf("/%s%s", requestPath, lastEvaluatedKeyQuery)
 
-		var merkleRootsResponse exclusiveStartKeyPage[[]MerkleRoot]
+			var merkleRootsResponse exclusiveStartKeyPage[[]MerkleRoot]
 
-		err := wc.doHTTPRequest(ctx, http.MethodGet, url, nil, wc.xPriv, true, &merkleRootsResponse)
-		if err != nil {
-			return err
+			err := wc.doHTTPRequest(ctx, http.MethodGet, url, nil, wc.xPriv, true, &merkleRootsResponse)
+			if err != nil {
+				return err
+			}
+
+			if previousLastEvaluatedKey == merkleRootsResponse.Page.LastEvaluatedKey {
+				return ErrStaleLastEvaluatedKey
+			}
+
+			err = repo.SaveMerkleRoots(merkleRootsResponse.Content)
+			if err != nil {
+				return err
+			}
+
+			if merkleRootsResponse.Page.LastEvaluatedKey == "" {
+				break
+			}
+
+			lastEvaluatedKey = fmt.Sprintf("?lastEvaluatedKey=%s", merkleRootsResponse.Page.LastEvaluatedKey)
+			previousLastEvaluatedKey = merkleRootsResponse.Page.LastEvaluatedKey
 		}
-
-		err = repo.SaveMerkleRoots(merkleRootsResponse.Content)
-		if err != nil {
-			return err
-		}
-
-		if merkleRootsResponse.Page.LastEvaluatedKey == "" {
-			break
-		}
-
-		lastEvaluatedKey = fmt.Sprintf("?lastEvaluatedKey=%s", *&merkleRootsResponse.Page.LastEvaluatedKey)
 	}
 	return nil
 }

--- a/sync_merkleroots.go
+++ b/sync_merkleroots.go
@@ -5,47 +5,12 @@ import (
 	"fmt"
 	"net/http"
 	"time"
+
+	"github.com/bitcoin-sv/spv-wallet-go-client/models"
 )
 
-// exclusiveStartKeyPage represents a paginated response for database records using Exclusive Start Key paging
-type exclusiveStartKeyPage[T any] struct {
-	// List of records for the response
-	Content T
-	// Pagination details
-	Page exclusiveStartKeyPageInfo
-}
-
-// exclusiveStartKeyPageInfo represents the pagination information for limiting and sorting database query results
-type exclusiveStartKeyPageInfo struct {
-	// Field by which to order the results
-	OrderByField *string `json:"orderByField,omitempty"` // Optional ordering field
-	// Direction in which to order the results (ASC or DESC)
-	SortDirection *string `json:"sortDirection,omitempty"` // Optional sort direction
-	// Total count of elements
-	TotalElements int `json:"totalElements"`
-	// Size of the page or returned data
-	Size int `json:"size"`
-	// Last evaluated key returned from the database
-	LastEvaluatedKey string `json:"lastEvaluatedKey"`
-}
-
-// MerkleRoot holds the content of the synced Merkle root response
-type MerkleRoot struct {
-	MerkleRoot  string `json:"merkleRoot"`
-	BlockHeight int    `json:"blockHeight"`
-}
-
-// MerkleRootsRepository is an interface responsible for saving synced merkleroots and getting last evaluat key from database
-type MerkleRootsRepository interface {
-	// GetLastMerkleRoot should return the merkle root with the heighest height from your storage or undefined if empty
-	GetLastMerkleRoot() string
-	// SaveMerkleRoots should store newly synced merkle roots into your storage;
-	// NOTE: items are ordered with ascending order by block height
-	SaveMerkleRoots(syncedMerkleRoots []MerkleRoot) error
-}
-
 // SyncMerkleRoots syncs merkleroots known to spv-wallet with the client database
-func (wc *WalletClient) SyncMerkleRoots(ctx context.Context, repo MerkleRootsRepository, timeoutMs time.Duration) error {
+func (wc *WalletClient) SyncMerkleRoots(ctx context.Context, repo models.MerkleRootsRepository, timeoutMs time.Duration) error {
 	var cancel context.CancelFunc
 	if timeoutMs > 0 {
 		ctx, cancel = context.WithTimeout(ctx, timeoutMs)
@@ -68,14 +33,15 @@ func (wc *WalletClient) SyncMerkleRoots(ctx context.Context, repo MerkleRootsRep
 		default:
 			url := fmt.Sprintf("/%s%s", requestPath, lastEvaluatedKeyQuery)
 
-			var merkleRootsResponse exclusiveStartKeyPage[[]MerkleRoot]
+			var merkleRootsResponse models.ExclusiveStartKeyPage[[]models.MerkleRoot]
 
 			err := wc.doHTTPRequest(ctx, http.MethodGet, url, nil, wc.xPriv, true, &merkleRootsResponse)
 			if err != nil {
 				return err
 			}
 
-			if previousLastEvaluatedKey == merkleRootsResponse.Page.LastEvaluatedKey {
+			lastEvaluatedKey = merkleRootsResponse.Page.LastEvaluatedKey
+			if lastEvaluatedKey != "" && previousLastEvaluatedKey == lastEvaluatedKey {
 				return ErrStaleLastEvaluatedKey
 			}
 
@@ -84,13 +50,12 @@ func (wc *WalletClient) SyncMerkleRoots(ctx context.Context, repo MerkleRootsRep
 				return err
 			}
 
-			if merkleRootsResponse.Page.LastEvaluatedKey == "" {
-				break
+			previousLastEvaluatedKey = lastEvaluatedKey
+			if previousLastEvaluatedKey == "" {
+				return nil
 			}
 
-			lastEvaluatedKeyQuery = fmt.Sprintf("?lastEvaluatedKey=%s", merkleRootsResponse.Page.LastEvaluatedKey)
-			previousLastEvaluatedKey = merkleRootsResponse.Page.LastEvaluatedKey
+			lastEvaluatedKeyQuery = fmt.Sprintf("?lastEvaluatedKey=%s", previousLastEvaluatedKey)
 		}
 	}
-	return nil
 }

--- a/sync_merkleroots.go
+++ b/sync_merkleroots.go
@@ -40,6 +40,7 @@ type Repository interface {
 	SaveMerkleRoots(syncedMerkleRoots []MerkleRoot) error
 }
 
+// SyncMerkleRoots syncs merkleroots known to spv-wallet with the client database
 func (wc *WalletClient) SyncMerkleRoots(ctx context.Context, repo Repository) error {
 	lastEvaluatedKey := repo.GetLastEvaluatedKey()
 	requestPath := "merkleroots"

--- a/sync_merkleroots.go
+++ b/sync_merkleroots.go
@@ -88,7 +88,7 @@ func (wc *WalletClient) SyncMerkleRoots(ctx context.Context, repo MerkleRootsRep
 				break
 			}
 
-			lastEvaluatedKey = fmt.Sprintf("?lastEvaluatedKey=%s", merkleRootsResponse.Page.LastEvaluatedKey)
+			lastEvaluatedKeyQuery = fmt.Sprintf("?lastEvaluatedKey=%s", merkleRootsResponse.Page.LastEvaluatedKey)
 			previousLastEvaluatedKey = merkleRootsResponse.Page.LastEvaluatedKey
 		}
 	}

--- a/sync_merkleroots.go
+++ b/sync_merkleroots.go
@@ -37,7 +37,7 @@ func (wc *WalletClient) SyncMerkleRoots(ctx context.Context, repo models.MerkleR
 
 			err := wc.doHTTPRequest(ctx, http.MethodGet, url, nil, wc.xPriv, true, &merkleRootsResponse)
 			if err != nil {
-				return err
+				return WrapError(err)
 			}
 
 			lastEvaluatedKey = merkleRootsResponse.Page.LastEvaluatedKey

--- a/sync_merkleroots.go
+++ b/sync_merkleroots.go
@@ -1,0 +1,74 @@
+package walletclient
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+)
+
+// exclusiveStartKeyPage represents a paginated response for database records using Exclusive Start Key paging
+type exclusiveStartKeyPage[T any] struct {
+	// List of records for the response
+	Content T
+	// Pagination details
+	Page exclusiveStartKeyPageInfo
+}
+
+// exclusiveStartKeyPageInfo represents the pagination information for limiting and sorting database query results
+type exclusiveStartKeyPageInfo struct {
+	// Field by which to order the results
+	OrderByField *string `json:"orderByField,omitempty"` // Optional ordering field
+	// Direction in which to order the results (ASC or DESC)
+	SortDirection *string `json:"sortDirection,omitempty"` // Optional sort direction
+	// Total count of elements
+	TotalElements int `json:"totalElements"`
+	// Size of the page or returned data
+	Size int `json:"size"`
+	// Last evaluated key returned from the database
+	LastEvaluatedKey string `json:"lastEvaluatedKey"`
+}
+
+// MerkleRoot holds the content of the synced Merkle root response
+type MerkleRoot struct {
+	MerkleRoot  string `json:"merkleRoot"`
+	BlockHeight int    `json:"blockHeight"`
+}
+
+// Repository is an interface responsible for saving synced merkleroots and getting last evaluat key from database
+type Repository interface {
+	GetLastEvaluatedKey() string
+	SaveMerkleRoots(syncedMerkleRoots []MerkleRoot) error
+}
+
+func (wc *WalletClient) SyncMerkleRoots(ctx context.Context, repo Repository) error {
+	lastEvaluatedKey := repo.GetLastEvaluatedKey()
+	requestPath := "merkleroots"
+	lastEvaluatedKeyQuery := ""
+
+	if lastEvaluatedKey != "" {
+		lastEvaluatedKeyQuery = fmt.Sprintf("?lastEvaluatedKey=%s", lastEvaluatedKey)
+	}
+
+	for {
+		url := fmt.Sprintf("/%s%s", requestPath, lastEvaluatedKeyQuery)
+
+		var merkleRootsResponse exclusiveStartKeyPage[[]MerkleRoot]
+
+		err := wc.doHTTPRequest(ctx, http.MethodGet, url, nil, wc.xPriv, true, &merkleRootsResponse)
+		if err != nil {
+			return err
+		}
+
+		err = repo.SaveMerkleRoots(merkleRootsResponse.Content)
+		if err != nil {
+			return err
+		}
+
+		if merkleRootsResponse.Page.LastEvaluatedKey == "" {
+			break
+		}
+
+		lastEvaluatedKey = fmt.Sprintf("?lastEvaluatedKey=%s", *&merkleRootsResponse.Page.LastEvaluatedKey)
+	}
+	return nil
+}

--- a/sync_merkleroots_test.go
+++ b/sync_merkleroots_test.go
@@ -1,0 +1,100 @@
+package walletclient
+
+import (
+	"context"
+	"testing"
+
+	"github.com/bitcoin-sv/spv-wallet-go-client/fixtures"
+	"github.com/bitcoin-sv/spv-wallet-go-client/models"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSyncMerkleRoots(t *testing.T) {
+
+	t.Run("Should properly sync database when empty", func(t *testing.T) {
+		// setup
+		server := fixtures.MockMerkleRootsAPIResponseNormal()
+		defer server.Close()
+
+		// given
+		repo := fixtures.CreateRepository([]models.MerkleRoot{})
+		client := NewWithXPriv(server.URL, fixtures.XPrivString)
+		require.NotNil(t, client.xPriv)
+
+		// when
+		err := client.SyncMerkleRoots(context.Background(), repo, 0)
+
+		// then
+		require.NoError(t, err)
+		require.Equal(t, len(fixtures.MockedSPVWalletData), len(repo.MerkleRoots))
+		require.Equal(t, fixtures.MockedSPVWalletData[len(fixtures.MockedSPVWalletData)-1].MerkleRoot, repo.MerkleRoots[len(repo.MerkleRoots)-1].MerkleRoot)
+		require.Equal(t, fixtures.MockedSPVWalletData[len(fixtures.MockedSPVWalletData)-1].BlockHeight, repo.MerkleRoots[len(repo.MerkleRoots)-1].BlockHeight)
+	})
+
+	t.Run("Should properly sync database when partially filled", func(t *testing.T) {
+		// setup
+		server := fixtures.MockMerkleRootsAPIResponseNormal()
+		defer server.Close()
+
+		// given
+		repo := fixtures.CreateRepository([]models.MerkleRoot{
+			{
+				MerkleRoot:  "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b",
+				BlockHeight: 0,
+			},
+			{
+				MerkleRoot:  "0e3e2357e806b6cdb1f70b54c3a3a17b6714ee1f0e68bebb44a74b1efd512098",
+				BlockHeight: 1,
+			},
+			{
+				MerkleRoot:  "9b0fc92260312ce44e74ef369f5c66bbb85848f2eddd5a7a1cde251e54ccfdd5",
+				BlockHeight: 2,
+			},
+		})
+		client := NewWithXPriv(server.URL, fixtures.XPrivString)
+		require.NotNil(t, client.xPriv)
+
+		// when
+		err := client.SyncMerkleRoots(context.Background(), repo, 0)
+
+		// then
+		require.NoError(t, err)
+		require.Equal(t, len(fixtures.MockedSPVWalletData), len(repo.MerkleRoots))
+		require.Equal(t, fixtures.MockedSPVWalletData[len(fixtures.MockedSPVWalletData)-1].MerkleRoot, repo.MerkleRoots[len(repo.MerkleRoots)-1].MerkleRoot)
+		require.Equal(t, fixtures.MockedSPVWalletData[len(fixtures.MockedSPVWalletData)-1].BlockHeight, repo.MerkleRoots[len(repo.MerkleRoots)-1].BlockHeight)
+	})
+
+	t.Run("Should fail sync merkleroots due to the time out", func(t *testing.T) {
+		// setup
+		server := fixtures.MockMerkleRootsAPIResponseDelayed()
+		defer server.Close()
+
+		// given
+		repo := fixtures.CreateRepository([]models.MerkleRoot{})
+		client := NewWithXPriv(server.URL, fixtures.XPrivString)
+		require.NotNil(t, client.xPriv)
+
+		// when
+		err := client.SyncMerkleRoots(context.Background(), repo, 10)
+
+		// then
+		require.ErrorIs(t, err, ErrSyncMerkleRootsTimeout)
+	})
+
+	t.Run("Should fail sync merkleroots due to last evaluated key being the same in the response", func(t *testing.T) {
+		// setup
+		server := fixtures.MockMerkleRootsAPIResponseStale()
+		defer server.Close()
+
+		// given
+		repo := fixtures.CreateRepository([]models.MerkleRoot{})
+		client := NewWithXPriv(server.URL, fixtures.XPrivString)
+		require.NotNil(t, client.xPriv)
+
+		// when
+		err := client.SyncMerkleRoots(context.Background(), repo, 0)
+
+		// then
+		require.ErrorIs(t, err, ErrStaleLastEvaluatedKey)
+	})
+}

--- a/sync_merkleroots_test.go
+++ b/sync_merkleroots_test.go
@@ -20,7 +20,6 @@ func TestSyncMerkleRoots(t *testing.T) {
 		// given
 		repo := fixtures.CreateRepository([]models.MerkleRoot{})
 		client, err := NewWithXPriv(server.URL, fixtures.XPrivString)
-		require.NotNil(t, client.xPriv)
 		require.NoError(t, err)
 
 		// when
@@ -53,7 +52,6 @@ func TestSyncMerkleRoots(t *testing.T) {
 			},
 		})
 		client, err := NewWithXPriv(server.URL, fixtures.XPrivString)
-		require.NotNil(t, client.xPriv)
 		require.NoError(t, err)
 
 		// when
@@ -76,7 +74,6 @@ func TestSyncMerkleRoots(t *testing.T) {
 		defer cancel()
 
 		client, err := NewWithXPriv(server.URL, fixtures.XPrivString)
-		require.NotNil(t, client.xPriv)
 		require.NoError(t, err)
 
 		// when
@@ -94,7 +91,6 @@ func TestSyncMerkleRoots(t *testing.T) {
 		// given
 		repo := fixtures.CreateRepository([]models.MerkleRoot{})
 		client, err := NewWithXPriv(server.URL, fixtures.XPrivString)
-		require.NotNil(t, client.xPriv)
 		require.NoError(t, err)
 
 		// when

--- a/sync_merkleroots_test.go
+++ b/sync_merkleroots_test.go
@@ -18,11 +18,12 @@ func TestSyncMerkleRoots(t *testing.T) {
 
 		// given
 		repo := fixtures.CreateRepository([]models.MerkleRoot{})
-		client := NewWithXPriv(server.URL, fixtures.XPrivString)
+		client, err := NewWithXPriv(server.URL, fixtures.XPrivString)
 		require.NotNil(t, client.xPriv)
+		require.NoError(t, err)
 
 		// when
-		err := client.SyncMerkleRoots(context.Background(), repo, 0)
+		err = client.SyncMerkleRoots(context.Background(), repo, 0)
 
 		// then
 		require.NoError(t, err)
@@ -51,11 +52,12 @@ func TestSyncMerkleRoots(t *testing.T) {
 				BlockHeight: 2,
 			},
 		})
-		client := NewWithXPriv(server.URL, fixtures.XPrivString)
+		client, err := NewWithXPriv(server.URL, fixtures.XPrivString)
 		require.NotNil(t, client.xPriv)
+		require.NoError(t, err)
 
 		// when
-		err := client.SyncMerkleRoots(context.Background(), repo, 0)
+		err = client.SyncMerkleRoots(context.Background(), repo, 0)
 
 		// then
 		require.NoError(t, err)
@@ -71,11 +73,12 @@ func TestSyncMerkleRoots(t *testing.T) {
 
 		// given
 		repo := fixtures.CreateRepository([]models.MerkleRoot{})
-		client := NewWithXPriv(server.URL, fixtures.XPrivString)
+		client, err := NewWithXPriv(server.URL, fixtures.XPrivString)
 		require.NotNil(t, client.xPriv)
+		require.NoError(t, err)
 
 		// when
-		err := client.SyncMerkleRoots(context.Background(), repo, 10)
+		err = client.SyncMerkleRoots(context.Background(), repo, 10)
 
 		// then
 		require.ErrorIs(t, err, ErrSyncMerkleRootsTimeout)
@@ -88,11 +91,12 @@ func TestSyncMerkleRoots(t *testing.T) {
 
 		// given
 		repo := fixtures.CreateRepository([]models.MerkleRoot{})
-		client := NewWithXPriv(server.URL, fixtures.XPrivString)
+		client, err := NewWithXPriv(server.URL, fixtures.XPrivString)
 		require.NotNil(t, client.xPriv)
+		require.NoError(t, err)
 
 		// when
-		err := client.SyncMerkleRoots(context.Background(), repo, 0)
+		err = client.SyncMerkleRoots(context.Background(), repo, 0)
 
 		// then
 		require.ErrorIs(t, err, ErrStaleLastEvaluatedKey)


### PR DESCRIPTION


- [x] 📖 I created my PR using provided  : [CODE_STANDARDS](https://github.com/bitcoin-sv/spv-wallet-go-client/blob/main/.github/CODE_STANDARDS.md)
- [x] 📖 I have read the short Code of Conduct: [CODE_OF_CONDUCT](https://github.com/bitcoin-sv/spv-wallet-go-client/blob/main/.github/CODE_OF_CONDUCT.md)
- [x] 🏠 I tested my changes locally.
- [ ] ✅ I have provided tests for my changes.
- [x] 📝 I have used conventional commits.
- [ ] 📗 I have updated any related documentation.
- [x] 💾 PR was issued based on the Github or Jira issue.

# NOTE

This PR does not include any new tests because regression tests are created in a separate service. Additionally, the structure of the sync merkleroots cannot guarantee consistent test results due to the ongoing growth of the blockchain. 

Furthermore, xpriv is used here instead of xpub, as in contrast to jsclient, because there is no straightforward way to handle xpub authentication in go client. Using xpriv with the sign flag set to true automatically sets the authorization header as xpub.

Any reviewers that want to discuss any of these issues please feel free to do so in the comments.

